### PR TITLE
Add shadcn-powered landing and portals

### DIFF
--- a/ensureback-ui/components.json
+++ b/ensureback-ui/components.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "tailwind.config.js",
+    "css": "src/index.css",
+    "baseColor": "slate",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils"
+  }
+}

--- a/ensureback-ui/index.html
+++ b/ensureback-ui/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <title>EnsureBack</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ensureback-ui/package.json
+++ b/ensureback-ui/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "ensureback-ui",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "tsc --noEmit",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.51.23",
+    "axios": "^1.7.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1",
+    "@radix-ui/react-dialog": "^1.0.5",
+    "@radix-ui/react-slot": "^1.0.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.428.0",
+    "tailwind-merge": "^2.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.12",
+    "tailwindcss-animate": "^1.0.7"
+  }
+}

--- a/ensureback-ui/postcss.config.js
+++ b/ensureback-ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/ensureback-ui/src/App.tsx
+++ b/ensureback-ui/src/App.tsx
@@ -1,0 +1,53 @@
+import type { ReactElement } from 'react';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
+
+import NavBar from '@/components/NavBar';
+import { useAuth } from '@/hooks/useAuth';
+import BuyerOrders from '@/pages/BuyerOrders';
+import Dashboard from '@/pages/Dashboard';
+import DeveloperCenter from '@/pages/DeveloperCenter';
+import Landing from '@/pages/Landing';
+import Login from '@/pages/Login';
+
+const ProtectedRoute = ({ children }: { children: ReactElement }) => {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return children;
+};
+
+const App = () => {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <NavBar />
+      <Routes>
+        <Route path="/" element={<Landing />} />
+        <Route path="/developer" element={<DeveloperCenter />} />
+        <Route path="/login" element={<Login />} />
+        <Route
+          path="/dashboard"
+          element={
+            <ProtectedRoute>
+              <Dashboard />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/buyer/orders"
+          element={
+            <ProtectedRoute>
+              <BuyerOrders />
+            </ProtectedRoute>
+          }
+        />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </div>
+  );
+};
+
+export default App;

--- a/ensureback-ui/src/api/auth.ts
+++ b/ensureback-ui/src/api/auth.ts
@@ -1,0 +1,24 @@
+import axiosClient, { TOKEN_STORAGE_KEY } from './axiosClient';
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  accessToken: string;
+  tokenType: string;
+  expiresAt: string;
+  role: string;
+}
+
+export const login = async (payload: LoginRequest): Promise<LoginResponse> => {
+  const response = await axiosClient.post<LoginResponse>('/auth/login', payload);
+  return response.data;
+};
+
+export const logout = (): void => {
+  if (typeof window !== 'undefined') {
+    window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+  }
+};

--- a/ensureback-ui/src/api/axiosClient.ts
+++ b/ensureback-ui/src/api/axiosClient.ts
@@ -1,0 +1,32 @@
+import axios from 'axios';
+
+export const API_BASE_URL = '/api';
+export const TOKEN_STORAGE_KEY = 'ensureback_token';
+
+const axiosClient = axios.create({
+  baseURL: API_BASE_URL,
+  withCredentials: false
+});
+
+axiosClient.interceptors.request.use((config) => {
+  if (typeof window !== 'undefined') {
+    const token = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+    if (token) {
+      config.headers = config.headers ?? {};
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
+  return config;
+});
+
+axiosClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401 && typeof window !== 'undefined') {
+      window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default axiosClient;

--- a/ensureback-ui/src/components/NavBar.tsx
+++ b/ensureback-ui/src/components/NavBar.tsx
@@ -1,0 +1,74 @@
+import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom';
+
+import { Button } from '@/components/ui/button';
+import { Navbar, NavbarContent, NavbarSection } from '@/components/ui/navbar';
+import { useAuth } from '@/hooks/useAuth';
+import { cn } from '@/lib/utils';
+
+const activeLink = ({ isActive }: { isActive: boolean }) =>
+  cn(
+    'text-sm font-medium text-muted-foreground transition-colors hover:text-foreground',
+    isActive && 'text-foreground'
+  );
+
+const NavBar = () => {
+  const { isAuthenticated, logout } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleLogout = () => {
+    logout();
+    if (location.pathname !== '/login') {
+      navigate('/login');
+    }
+  };
+
+  return (
+    <Navbar>
+      <NavbarContent>
+        <NavbarSection className="gap-6">
+          <Link to="/" className="text-base font-semibold tracking-tight">
+            EnsureBack
+          </Link>
+          <a href="/#pricing" className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
+            Pricing
+          </a>
+          <a href="/#how-it-works" className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground">
+            How it works
+          </a>
+          <NavLink to="/developer" className={activeLink}>
+            Developer Center
+          </NavLink>
+          {isAuthenticated && (
+            <NavLink to="/dashboard" className={activeLink}>
+              Dashboard
+            </NavLink>
+          )}
+          {isAuthenticated && (
+            <NavLink to="/buyer/orders" className={activeLink}>
+              Buyer Portal
+            </NavLink>
+          )}
+        </NavbarSection>
+        <NavbarSection className="gap-3">
+          {!isAuthenticated ? (
+            <>
+              <Button asChild variant="ghost">
+                <Link to="/login">Login</Link>
+              </Button>
+              <Button asChild>
+                <Link to={isAuthenticated ? '/dashboard' : '/login'}>Get Started</Link>
+              </Button>
+            </>
+          ) : (
+            <Button variant="outline" onClick={handleLogout}>
+              Log out
+            </Button>
+          )}
+        </NavbarSection>
+      </NavbarContent>
+    </Navbar>
+  );
+};
+
+export default NavBar;

--- a/ensureback-ui/src/components/ui/button.tsx
+++ b/ensureback-ui/src/components/ui/button.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        outline: 'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline'
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+);
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, variant, size, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'button';
+  return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+});
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/ensureback-ui/src/components/ui/card.tsx
+++ b/ensureback-ui/src/components/ui/card.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)} {...props} />
+));
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+));
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(({ className, ...props }, ref) => (
+  <h3 ref={ref} className={cn('text-2xl font-semibold leading-none tracking-tight', className)} {...props} />
+));
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+));
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/ensureback-ui/src/components/ui/dialog.tsx
+++ b/ensureback-ui/src/components/ui/dialog.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { X } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+
+const DialogTrigger = DialogPrimitive.Trigger;
+
+const DialogPortal = ({ className, children, ...props }: DialogPrimitive.DialogPortalProps) => (
+  <DialogPrimitive.Portal className={cn(className)} {...props}>
+    <div className="fixed inset-0 z-50 flex items-start justify-center sm:items-center">
+      {children}
+    </div>
+  </DialogPrimitive.Portal>
+);
+DialogPortal.displayName = DialogPrimitive.Portal.displayName;
+
+const DialogOverlay = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Overlay>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      className={cn('fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in', className)}
+      {...props}
+    />
+  )
+);
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>>(
+  ({ className, children, ...props }, ref) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'fixed z-50 grid w-full gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-top-[48%] sm:max-w-lg',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+);
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+);
+DialogHeader.displayName = 'DialogHeader';
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
+);
+DialogFooter.displayName = 'DialogFooter';
+
+const DialogTitle = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Title>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Title ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+  )
+);
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+const DialogDescription = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Description>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+);
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
+
+export { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription, DialogOverlay };

--- a/ensureback-ui/src/components/ui/input.tsx
+++ b/ensureback-ui/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export { Input };

--- a/ensureback-ui/src/components/ui/navbar.tsx
+++ b/ensureback-ui/src/components/ui/navbar.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Navbar = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(({ className, ...props }, ref) => (
+  <nav ref={ref} className={cn('sticky top-0 z-40 w-full border-b bg-background/90 backdrop-blur supports-[backdrop-filter]:bg-background/60', className)} {...props} />
+));
+Navbar.displayName = 'Navbar';
+
+const NavbarContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('mx-auto flex h-16 max-w-6xl items-center justify-between px-4', className)} {...props} />
+));
+NavbarContent.displayName = 'NavbarContent';
+
+const NavbarSection = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('flex items-center gap-4', className)} {...props} />
+));
+NavbarSection.displayName = 'NavbarSection';
+
+export { Navbar, NavbarContent, NavbarSection };

--- a/ensureback-ui/src/components/ui/table.tsx
+++ b/ensureback-ui/src/components/ui/table.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(({ className, ...props }, ref) => (
+  <div className="w-full overflow-auto">
+    <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+  </div>
+));
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+);
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+);
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tfoot ref={ref} className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)} {...props} />
+  )
+);
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => <tr ref={ref} className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)} {...props} />
+);
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn('h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0', className)}
+      {...props}
+    />
+  )
+);
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<HTMLTableCellElement, React.TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => <td ref={ref} className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)} {...props} />
+);
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.HTMLAttributes<HTMLTableCaptionElement>>(
+  ({ className, ...props }, ref) => <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+);
+TableCaption.displayName = 'TableCaption';
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/ensureback-ui/src/components/ui/textarea.tsx
+++ b/ensureback-ui/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/ensureback-ui/src/hooks/useAuth.ts
+++ b/ensureback-ui/src/hooks/useAuth.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { login as loginRequest, logout as logoutRequest, LoginRequest, LoginResponse } from '../api/auth';
+import { TOKEN_STORAGE_KEY } from '../api/axiosClient';
+
+const getInitialToken = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window.localStorage.getItem(TOKEN_STORAGE_KEY);
+};
+
+interface UseAuthResult {
+  token: string | null;
+  isAuthenticated: boolean;
+  isLoggingIn: boolean;
+  loginError: unknown;
+  login: (credentials: LoginRequest) => Promise<LoginResponse>;
+  logout: () => void;
+}
+
+export const useAuth = (): UseAuthResult => {
+  const queryClient = useQueryClient();
+  const [token, setToken] = useState<string | null>(getInitialToken);
+
+  useEffect(() => {
+    const handler = (event: StorageEvent) => {
+      if (event.key === TOKEN_STORAGE_KEY) {
+        setToken(event.newValue);
+      }
+    };
+
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }, []);
+
+  const loginMutation = useMutation({
+    mutationFn: (credentials: LoginRequest) => loginRequest(credentials),
+    onSuccess: (data) => {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(TOKEN_STORAGE_KEY, data.accessToken);
+      }
+      setToken(data.accessToken);
+    },
+  });
+
+  const logout = useCallback(() => {
+    logoutRequest();
+    setToken(null);
+    queryClient.clear();
+  }, [queryClient]);
+
+  const login = useCallback(
+    (credentials: LoginRequest) => loginMutation.mutateAsync(credentials),
+    [loginMutation]
+  );
+
+  return useMemo(
+    () => ({
+      token,
+      isAuthenticated: Boolean(token),
+      isLoggingIn: loginMutation.isPending,
+      loginError: loginMutation.error,
+      login,
+      logout,
+    }),
+    [login, loginMutation.error, loginMutation.isPending, logout, token]
+  );
+};

--- a/ensureback-ui/src/index.css
+++ b/ensureback-ui/src/index.css
@@ -1,0 +1,78 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+
+    --primary: 222.2 47.4% 11.2%;
+    --primary-foreground: 210 40% 98%;
+
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+
+    --ring: 222.2 84% 4.9%;
+
+    --radius: 0.75rem;
+  }
+
+  .dark {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+
+    --popover: 222.2 84% 4.9%;
+    --popover-foreground: 210 40% 98%;
+
+    --card: 222.2 84% 4.9%;
+    --card-foreground: 210 40% 98%;
+
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 98%;
+
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 98%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+
+    --ring: 212.7 26.8% 83.9%;
+  }
+
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+    font-feature-settings: 'rlig' 1, 'calt' 1;
+  }
+}

--- a/ensureback-ui/src/lib/utils.ts
+++ b/ensureback-ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/ensureback-ui/src/main.tsx
+++ b/ensureback-ui/src/main.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import App from './App';
+import './index.css';
+
+const queryClient = new QueryClient();
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/ensureback-ui/src/pages/BuyerOrders.tsx
+++ b/ensureback-ui/src/pages/BuyerOrders.tsx
@@ -1,0 +1,224 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Check, MessageCircle, Package, X } from 'lucide-react';
+
+import axiosClient from '@/api/axiosClient';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+interface BuyerOrder {
+  orderId: string;
+  productName: string;
+  status: 'processing' | 'shipped' | 'delivered' | 'disputed';
+  total: number;
+  currency: string;
+  updatedAt: string;
+  disputeStatus?: 'open' | 'resolved' | 'partial_refund';
+  partialRefundOffer?: number;
+}
+
+const fetchBuyerOrders = async (): Promise<BuyerOrder[]> => {
+  try {
+    const response = await axiosClient.get<BuyerOrder[]>('/buyer/orders');
+    return response.data;
+  } catch (error) {
+    const now = Date.now();
+    return [
+      {
+        orderId: 'ORDER-12345',
+        productName: 'Wireless Earbuds',
+        status: 'processing',
+        total: 12500,
+        currency: 'usd',
+        updatedAt: new Date(now - 1000 * 60 * 15).toISOString()
+      },
+      {
+        orderId: 'ORDER-67890',
+        productName: 'Mechanical Keyboard',
+        status: 'delivered',
+        total: 18900,
+        currency: 'usd',
+        updatedAt: new Date(now - 1000 * 60 * 60 * 18).toISOString(),
+        disputeStatus: 'open',
+        partialRefundOffer: 5000
+      },
+      {
+        orderId: 'ORDER-24680',
+        productName: '4K Monitor',
+        status: 'disputed',
+        total: 32900,
+        currency: 'usd',
+        updatedAt: new Date(now - 1000 * 60 * 60 * 42).toISOString(),
+        disputeStatus: 'partial_refund',
+        partialRefundOffer: 8000
+      }
+    ];
+  }
+};
+
+const formatCurrency = (amount: number, currency: string) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: currency.toUpperCase() }).format(amount / 100);
+
+const BuyerOrders = () => {
+  const { data, isLoading } = useQuery({ queryKey: ['buyer', 'orders'], queryFn: fetchBuyerOrders });
+  const [disputeOrder, setDisputeOrder] = useState<BuyerOrder | null>(null);
+  const [disputeMessage, setDisputeMessage] = useState('');
+  const [evidence, setEvidence] = useState<File | null>(null);
+
+  const resetModal = () => {
+    setDisputeOrder(null);
+    setDisputeMessage('');
+    setEvidence(null);
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-12">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Buyer Portal</h1>
+        <p className="text-muted-foreground">
+          View order progress, start disputes, and negotiate partial refunds without leaving EnsureBack.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <CardTitle>Orders</CardTitle>
+            <CardDescription>All of your EnsureBack protected orders and their current status.</CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Order</TableHead>
+                <TableHead>Product</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead className="text-right">Updated</TableHead>
+                <TableHead className="text-right">Total</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading && (
+                <TableRow>
+                  <TableCell colSpan={6} className="py-12 text-center text-muted-foreground">
+                    Loading buyer orders…
+                  </TableCell>
+                </TableRow>
+              )}
+              {data?.map((order) => (
+                <TableRow key={order.orderId}>
+                  <TableCell className="font-medium">{order.orderId}</TableCell>
+                  <TableCell>{order.productName}</TableCell>
+                  <TableCell>
+                    <span
+                      className={cn(
+                        'inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium capitalize',
+                        order.status === 'processing' && 'bg-amber-100 text-amber-700',
+                        order.status === 'delivered' && 'bg-emerald-100 text-emerald-700',
+                        order.status === 'shipped' && 'bg-blue-100 text-blue-700',
+                        order.status === 'disputed' && 'bg-red-100 text-red-700'
+                      )}
+                    >
+                      {order.status}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-right text-sm text-muted-foreground">
+                    {new Date(order.updatedAt).toLocaleString()}
+                  </TableCell>
+                  <TableCell className="text-right font-medium">
+                    {formatCurrency(order.total, order.currency)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setDisputeOrder(order)}
+                        className="flex items-center gap-1"
+                      >
+                        <MessageCircle className="h-4 w-4" />
+                        {order.disputeStatus ? 'Update dispute' : 'Open dispute'}
+                      </Button>
+                      {order.partialRefundOffer && (
+                        <Button variant="ghost" size="sm" className="flex items-center gap-1">
+                          <Package className="h-4 w-4" /> Offer {formatCurrency(order.partialRefundOffer, order.currency)}
+                        </Button>
+                      )}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <Dialog open={Boolean(disputeOrder)} onOpenChange={(open) => {
+        if (!open) {
+          resetModal();
+        }
+      }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Dispute order {disputeOrder?.orderId}</DialogTitle>
+            <DialogDescription>
+              Share what went wrong and add evidence so the seller can respond quickly.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="grid gap-2">
+              <label htmlFor="message" className="text-sm font-medium">
+                Message to seller
+              </label>
+              <Textarea
+                id="message"
+                value={disputeMessage}
+                onChange={(event) => setDisputeMessage(event.target.value)}
+                placeholder="Describe the issue you're experiencing"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label htmlFor="evidence" className="text-sm font-medium">
+                Upload evidence
+              </label>
+              <Input id="evidence" type="file" onChange={(event) => setEvidence(event.target.files?.[0] ?? null)} />
+              {evidence && <p className="text-xs text-muted-foreground">Attached: {evidence.name}</p>}
+            </div>
+            {disputeOrder?.partialRefundOffer && (
+              <div className="rounded-lg border bg-muted/40 p-4 text-sm">
+                <p className="font-medium">Partial refund offer available</p>
+                <p className="text-muted-foreground">
+                  The seller proposed {formatCurrency(disputeOrder.partialRefundOffer, disputeOrder.currency)} to resolve this
+                  dispute.
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button variant="default" size="sm" className="flex items-center gap-1">
+                    <Check className="h-4 w-4" /> Accept offer
+                  </Button>
+                  <Button variant="outline" size="sm" className="flex items-center gap-1">
+                    <X className="h-4 w-4" /> Decline
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button variant="ghost" onClick={resetModal}>
+              Cancel
+            </Button>
+            <Button onClick={resetModal}>Submit dispute</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+};
+
+export default BuyerOrders;

--- a/ensureback-ui/src/pages/Dashboard.tsx
+++ b/ensureback-ui/src/pages/Dashboard.tsx
@@ -1,0 +1,376 @@
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { AlertCircle, ArrowUpRight, RefreshCw, ShieldAlert } from 'lucide-react';
+
+import axiosClient from '@/api/axiosClient';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+interface MerchantProfile {
+  id: string;
+  email: string;
+  role: string;
+  createdAt: string;
+  stripeAccountId?: string;
+}
+
+interface MerchantOrder {
+  id: string;
+  customerEmail: string;
+  status: 'processing' | 'fulfilled' | 'disputed';
+  amount: number;
+  currency: string;
+  updatedAt: string;
+}
+
+interface MerchantDispute {
+  id: string;
+  orderId: string;
+  status: 'open' | 'closed' | 'partial_refund';
+  reason: string;
+  openedAt: string;
+}
+
+interface MerchantBalance {
+  escrow: number;
+  available: number;
+  currency: string;
+}
+
+const fetchMerchantProfile = async (): Promise<MerchantProfile> => {
+  const response = await axiosClient.get<MerchantProfile>('/merchant/me');
+  return response.data;
+};
+
+const fetchOrders = async (): Promise<MerchantOrder[]> => {
+  try {
+    const response = await axiosClient.get<MerchantOrder[]>('/merchant/orders');
+    return response.data;
+  } catch (error) {
+    const now = Date.now();
+    return [
+      {
+        id: 'ord_12345',
+        customerEmail: 'buyer1@example.com',
+        status: 'processing',
+        amount: 12900,
+        currency: 'usd',
+        updatedAt: new Date(now - 1000 * 60 * 45).toISOString()
+      },
+      {
+        id: 'ord_67890',
+        customerEmail: 'buyer2@example.com',
+        status: 'fulfilled',
+        amount: 8900,
+        currency: 'usd',
+        updatedAt: new Date(now - 1000 * 60 * 60 * 7).toISOString()
+      },
+      {
+        id: 'ord_24680',
+        customerEmail: 'buyer3@example.com',
+        status: 'disputed',
+        amount: 21000,
+        currency: 'usd',
+        updatedAt: new Date(now - 1000 * 60 * 60 * 30).toISOString()
+      }
+    ];
+  }
+};
+
+const fetchDisputes = async (): Promise<MerchantDispute[]> => {
+  try {
+    const response = await axiosClient.get<MerchantDispute[]>('/merchant/disputes');
+    return response.data;
+  } catch (error) {
+    const now = Date.now();
+    return [
+      {
+        id: 'dp_101',
+        orderId: 'ord_24680',
+        status: 'open',
+        reason: 'Item not as described',
+        openedAt: new Date(now - 1000 * 60 * 60 * 24).toISOString()
+      },
+      {
+        id: 'dp_205',
+        orderId: 'ord_13579',
+        status: 'partial_refund',
+        reason: 'Shipping delay',
+        openedAt: new Date(now - 1000 * 60 * 60 * 72).toISOString()
+      },
+      {
+        id: 'dp_309',
+        orderId: 'ord_54321',
+        status: 'closed',
+        reason: 'Resolved in buyer favor',
+        openedAt: new Date(now - 1000 * 60 * 60 * 96).toISOString()
+      }
+    ];
+  }
+};
+
+const fetchBalance = async (): Promise<MerchantBalance> => {
+  try {
+    const response = await axiosClient.get<MerchantBalance>('/merchant/balance');
+    return response.data;
+  } catch (error) {
+    return { escrow: 235000, available: 128500, currency: 'usd' };
+  }
+};
+
+const formatCurrency = (amount: number, currency: string) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: currency.toUpperCase() }).format(amount / 100);
+
+const Dashboard = () => {
+  const [activeTab, setActiveTab] = useState<'overview' | 'orders' | 'disputes' | 'balance'>('overview');
+
+  const profileQuery = useQuery({ queryKey: ['merchant', 'profile'], queryFn: fetchMerchantProfile });
+  const ordersQuery = useQuery({ queryKey: ['merchant', 'orders'], queryFn: fetchOrders });
+  const disputesQuery = useQuery({ queryKey: ['merchant', 'disputes'], queryFn: fetchDisputes });
+  const balanceQuery = useQuery({ queryKey: ['merchant', 'balance'], queryFn: fetchBalance });
+
+  const disputeStats = useMemo(() => {
+    if (!disputesQuery.data) return { open: 0, closed: 0, partial: 0 };
+    return {
+      open: disputesQuery.data.filter((d) => d.status === 'open').length,
+      closed: disputesQuery.data.filter((d) => d.status === 'closed').length,
+      partial: disputesQuery.data.filter((d) => d.status === 'partial_refund').length
+    };
+  }, [disputesQuery.data]);
+
+  const tabs = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'orders', label: 'Orders' },
+    { id: 'disputes', label: 'Disputes' },
+    { id: 'balance', label: 'Balance' }
+  ] as const;
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-12">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Merchant Dashboard</h1>
+        <p className="text-muted-foreground">
+          Monitor your EnsureBack account, manage disputes, and keep buyers protected.
+        </p>
+      </header>
+
+      <div className="flex flex-wrap gap-3">
+        {tabs.map((tab) => (
+          <Button
+            key={tab.id}
+            variant={activeTab === tab.id ? 'default' : 'outline'}
+            onClick={() => setActiveTab(tab.id)}
+            className="rounded-full"
+          >
+            {tab.label}
+          </Button>
+        ))}
+      </div>
+
+      {activeTab === 'overview' && (
+        <div className="grid gap-6 md:grid-cols-2">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between">
+              <div>
+                <CardTitle>Account details</CardTitle>
+                <CardDescription>Signed in as {profileQuery.data?.email ?? 'loading…'}</CardDescription>
+              </div>
+              <Button variant="ghost" size="sm" onClick={() => profileQuery.refetch()} disabled={profileQuery.isLoading}>
+                <RefreshCw className="mr-2 h-4 w-4" /> Refresh
+              </Button>
+            </CardHeader>
+            <CardContent className="space-y-4 text-sm">
+              <div className="flex flex-col gap-2">
+                <span className="text-muted-foreground">Merchant ID</span>
+                <span className="font-medium">{profileQuery.data?.id ?? '—'}</span>
+              </div>
+              <div className="flex flex-col gap-2">
+                <span className="text-muted-foreground">Role</span>
+                <span className="font-medium">{profileQuery.data?.role ?? '—'}</span>
+              </div>
+              <div className="flex flex-col gap-2">
+                <span className="text-muted-foreground">Joined</span>
+                <span className="font-medium">
+                  {profileQuery.data ? new Date(profileQuery.data.createdAt).toLocaleString() : '—'}
+                </span>
+              </div>
+              <div className="flex flex-col gap-2">
+                <span className="text-muted-foreground">Stripe account</span>
+                <span className="font-medium">{profileQuery.data?.stripeAccountId ?? 'Connect to Stripe'}</span>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <ShieldAlert className="h-5 w-5 text-primary" /> Dispute summary
+              </CardTitle>
+              <CardDescription>Track open cases and partial refunds.</CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-3 text-sm md:grid-cols-3">
+              <div className="rounded-lg border bg-muted/40 p-4">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Open</p>
+                <p className="mt-2 text-2xl font-semibold">{disputeStats.open}</p>
+              </div>
+              <div className="rounded-lg border bg-muted/40 p-4">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Closed</p>
+                <p className="mt-2 text-2xl font-semibold">{disputeStats.closed}</p>
+              </div>
+              <div className="rounded-lg border bg-muted/40 p-4">
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Partial refunds</p>
+                <p className="mt-2 text-2xl font-semibold">{disputeStats.partial}</p>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+
+      {activeTab === 'orders' && (
+        <Card>
+          <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <CardTitle>Recent orders</CardTitle>
+              <CardDescription>Latest payments captured through EnsureBack.</CardDescription>
+            </div>
+            <Button variant="ghost" size="sm" onClick={() => ordersQuery.refetch()} disabled={ordersQuery.isLoading}>
+              <RefreshCw className="mr-2 h-4 w-4" /> Refresh
+            </Button>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Order</TableHead>
+                  <TableHead>Customer</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Amount</TableHead>
+                  <TableHead className="text-right">Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {ordersQuery.data?.map((order) => (
+                  <TableRow key={order.id}>
+                    <TableCell className="font-medium">{order.id}</TableCell>
+                    <TableCell>{order.customerEmail}</TableCell>
+                    <TableCell>
+                      <span
+                        className={cn(
+                          'rounded-full px-3 py-1 text-xs font-medium capitalize',
+                          order.status === 'fulfilled' && 'bg-emerald-100 text-emerald-700',
+                          order.status === 'processing' && 'bg-amber-100 text-amber-700',
+                          order.status === 'disputed' && 'bg-red-100 text-red-700'
+                        )}
+                      >
+                        {order.status}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right">{formatCurrency(order.amount, order.currency)}</TableCell>
+                    <TableCell className="text-right">
+                      {new Date(order.updatedAt).toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      {activeTab === 'disputes' && (
+        <Card>
+          <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <CardTitle>Disputes</CardTitle>
+              <CardDescription>Filter by outcome and respond to buyers quickly.</CardDescription>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => disputesQuery.refetch()}
+                disabled={disputesQuery.isLoading}
+              >
+                <RefreshCw className="mr-2 h-4 w-4" /> Refresh
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex flex-wrap gap-2 text-sm">
+              <span className="inline-flex items-center gap-2 rounded-full border bg-muted/40 px-3 py-1">
+                <AlertCircle className="h-4 w-4 text-amber-600" /> Open {disputeStats.open}
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full border bg-muted/40 px-3 py-1">
+                <ArrowUpRight className="h-4 w-4 text-emerald-600" /> Partial refunds {disputeStats.partial}
+              </span>
+              <span className="inline-flex items-center gap-2 rounded-full border bg-muted/40 px-3 py-1">
+                <ShieldAlert className="h-4 w-4 text-slate-600" /> Closed {disputeStats.closed}
+              </span>
+            </div>
+            <div className="grid gap-4">
+              {disputesQuery.data?.map((dispute) => (
+                <div key={dispute.id} className="rounded-lg border bg-card p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p className="text-sm font-semibold">{dispute.reason}</p>
+                      <p className="text-xs text-muted-foreground">Order {dispute.orderId}</p>
+                    </div>
+                    <span
+                      className={cn(
+                        'rounded-full px-3 py-1 text-xs font-medium capitalize',
+                        dispute.status === 'open' && 'bg-amber-100 text-amber-700',
+                        dispute.status === 'closed' && 'bg-emerald-100 text-emerald-700',
+                        dispute.status === 'partial_refund' && 'bg-blue-100 text-blue-700'
+                      )}
+                    >
+                      {dispute.status.replace('_', ' ')}
+                    </span>
+                  </div>
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    Opened {new Date(dispute.openedAt).toLocaleString()}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {activeTab === 'balance' && (
+        <Card>
+          <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <CardTitle>Balance overview</CardTitle>
+              <CardDescription>Escrow versus available payouts.</CardDescription>
+            </div>
+            <Button variant="ghost" size="sm" onClick={() => balanceQuery.refetch()} disabled={balanceQuery.isLoading}>
+              <RefreshCw className="mr-2 h-4 w-4" /> Refresh
+            </Button>
+          </CardHeader>
+          <CardContent className="grid gap-6 md:grid-cols-2">
+            <div className="rounded-lg border bg-muted/40 p-6">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Escrow balance</p>
+              <p className="mt-3 text-3xl font-semibold">
+                {balanceQuery.data ? formatCurrency(balanceQuery.data.escrow, balanceQuery.data.currency) : '—'}
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Held until delivery confirmation or dispute resolution.
+              </p>
+            </div>
+            <div className="rounded-lg border bg-muted/40 p-6">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Available balance</p>
+              <p className="mt-3 text-3xl font-semibold">
+                {balanceQuery.data ? formatCurrency(balanceQuery.data.available, balanceQuery.data.currency) : '—'}
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">Eligible for payout to your connected Stripe account.</p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/ensureback-ui/src/pages/DeveloperCenter.tsx
+++ b/ensureback-ui/src/pages/DeveloperCenter.tsx
@@ -1,0 +1,136 @@
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { CheckCircle2, KeyRound, Webhook } from 'lucide-react';
+import { useMemo } from 'react';
+
+import axiosClient from '@/api/axiosClient';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface ApiKeyResponse {
+  key: string;
+}
+
+const fetchIntegrationStatus = async () => {
+  try {
+    const response = await axiosClient.get<{ keysGenerated: boolean; webhookConfigured: boolean; testPassed: boolean }>(
+      '/developer/status'
+    );
+    return response.data;
+  } catch (error) {
+    return { keysGenerated: false, webhookConfigured: false, testPassed: false };
+  }
+};
+
+const DeveloperCenter = () => {
+  const generateKeyMutation = useMutation({
+    mutationFn: async () => {
+      try {
+        const response = await axiosClient.post<ApiKeyResponse>('/developer/keys');
+        return response.data;
+      } catch (error) {
+        return { key: 'sk_test_mock_123456789' };
+      }
+    }
+  });
+
+  const { data: integrationStatus, refetch } = useQuery({
+    queryKey: ['developer', 'status'],
+    queryFn: fetchIntegrationStatus
+  });
+
+  const checklist = useMemo(
+    () => [
+      { label: 'API keys generated', complete: Boolean(integrationStatus?.keysGenerated) },
+      { label: 'Webhook configured', complete: Boolean(integrationStatus?.webhookConfigured) },
+      { label: 'Test purchase passed', complete: Boolean(integrationStatus?.testPassed) }
+    ],
+    [integrationStatus]
+  );
+
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-12">
+      <header className="space-y-3 text-center md:text-left">
+        <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+          Build on EnsureBack
+        </span>
+        <h1 className="text-4xl font-semibold tracking-tight">Integrate EnsureBack in minutes</h1>
+        <p className="text-muted-foreground md:max-w-3xl">
+          Use our REST APIs to create escrow-backed payments, manage disputes programmatically, and keep buyers confident. Start
+          with sandbox credentials, then flip to live mode with Stripe Connect.
+        </p>
+      </header>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <KeyRound className="h-5 w-5 text-primary" /> API keys
+            </CardTitle>
+            <CardDescription>Generate sandbox keys instantly. Rotate at any time.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Button
+              size="lg"
+              disabled={generateKeyMutation.isPending}
+              onClick={() => generateKeyMutation.mutateAsync().then(() => refetch())}
+            >
+              {generateKeyMutation.isPending ? 'Generating…' : 'Generate new key'}
+            </Button>
+            {generateKeyMutation.data?.key && (
+              <div className="rounded-md border bg-muted/30 p-3 font-mono text-sm">
+                {generateKeyMutation.data.key}
+              </div>
+            )}
+            <p className="text-sm text-muted-foreground">
+              Keys are stored securely. Copy them into your environment variables before closing this page.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Webhook className="h-5 w-5 text-primary" /> Webhooks
+            </CardTitle>
+            <CardDescription>Receive real-time dispute and escrow status updates.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <pre className="rounded-md bg-muted/40 p-4 text-left text-sm">
+{`const eb = new EnsureBack("API_KEY");
+eb.createPayment({
+  amount: 1000,
+  product: "Premium Headphones"
+});`}
+            </pre>
+            <p className="text-sm text-muted-foreground">
+              Subscribe to <code className="rounded bg-muted px-1 py-0.5">payment.released</code> and{' '}
+              <code className="rounded bg-muted px-1 py-0.5">dispute.updated</code> events to stay in sync.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Integration checklist</CardTitle>
+          <CardDescription>Track onboarding tasks to productionize your integration.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-3">
+          {checklist.map((item) => (
+            <div key={item.label} className="flex items-center gap-3 rounded-lg border bg-card p-4">
+              <CheckCircle2 className={`h-5 w-5 ${item.complete ? 'text-green-500' : 'text-muted-foreground'}`} />
+              <div>
+                <p className="text-sm font-medium">{item.label}</p>
+                <p className="text-xs text-muted-foreground">
+                  {item.complete ? 'Completed' : 'Pending'}
+                </p>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default DeveloperCenter;

--- a/ensureback-ui/src/pages/Landing.tsx
+++ b/ensureback-ui/src/pages/Landing.tsx
@@ -1,0 +1,167 @@
+import { ArrowRight, ShieldCheck, Wallet } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+const howItWorks = [
+  {
+    title: 'Customer pays via Stripe',
+    description: 'Embed EnsureBack into your Stripe Checkout or Payment Links to keep funds protected from chargebacks.',
+    icon: <Wallet className="h-6 w-6 text-primary" />
+  },
+  {
+    title: 'Funds held in escrow',
+    description: 'EnsureBack keeps payouts in managed escrow accounts until delivery, reducing risk for both sides.',
+    icon: <ShieldCheck className="h-6 w-6 text-primary" />
+  },
+  {
+    title: 'Disputes resolved fairly',
+    description: 'Collaborative tooling allows buyers and sellers to negotiate, upload evidence, and settle in-app.',
+    icon: <ArrowRight className="h-6 w-6 text-primary" />
+  }
+];
+
+const Landing = () => {
+  return (
+    <div className="flex min-h-screen flex-col bg-background text-foreground">
+      <main className="flex-1">
+        <section className="mx-auto flex max-w-6xl flex-col items-start gap-6 px-4 pb-20 pt-24 text-left md:flex-row md:items-center md:justify-between">
+          <div className="max-w-2xl space-y-6">
+            <span className="inline-flex items-center rounded-full border border-primary/30 bg-primary/10 px-4 py-1 text-xs font-semibold uppercase tracking-wider text-primary">
+              Buyer protection for Stripe-first merchants
+            </span>
+            <h1 className="text-4xl font-semibold tracking-tight md:text-5xl">
+              Get Rid of PayPal; Offer Buyer Protection through Stripe
+            </h1>
+            <p className="text-lg text-muted-foreground">
+              EnsureBack gives your marketplace PayPal-grade protection with Stripe-native experiences, real-time dispute tooling,
+              and instant onboarding.
+            </p>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <Button asChild size="lg">
+                <Link to="/login" className="flex items-center gap-2">
+                  Get Started Free
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+              <Button asChild variant="outline" size="lg">
+                <a href="#pricing">See Pricing</a>
+              </Button>
+            </div>
+          </div>
+          <div className="hidden max-w-sm rounded-3xl border bg-card p-6 shadow-xl md:block">
+            <div className="space-y-4">
+              <h2 className="text-xl font-semibold">Stripe Connect for Escrow</h2>
+              <p className="text-sm text-muted-foreground">
+                Provide a seamless onboarding flow. Invite merchants, verify identity, and start protecting payments instantly.
+              </p>
+              <Button asChild variant="secondary" size="lg">
+                <a
+                  href="https://connect.stripe.com/oauth/authorize"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex items-center gap-2"
+                >
+                  Launch Connect Onboarding
+                  <ArrowRight className="h-4 w-4" />
+                </a>
+              </Button>
+            </div>
+          </div>
+        </section>
+
+        <section id="how-it-works" className="bg-muted/40 py-16">
+          <div className="mx-auto max-w-6xl px-4">
+            <div className="mb-10 max-w-2xl space-y-3">
+              <h2 className="text-3xl font-semibold tracking-tight">How it works</h2>
+              <p className="text-muted-foreground">
+                EnsureBack combines Stripe payments, escrow management, and collaborative dispute tooling into a single experience.
+              </p>
+            </div>
+            <div className="grid gap-6 md:grid-cols-3">
+              {howItWorks.map((step) => (
+                <Card key={step.title}>
+                  <CardHeader className="space-y-3">
+                    <div className="rounded-full bg-primary/10 p-3 text-primary">{step.icon}</div>
+                    <CardTitle className="text-xl">{step.title}</CardTitle>
+                    <CardDescription>{step.description}</CardDescription>
+                  </CardHeader>
+                </Card>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section id="pricing" className="py-16">
+          <div className="mx-auto max-w-5xl px-4 text-center">
+            <h2 className="text-3xl font-semibold">Simple, predictable pricing</h2>
+            <p className="mt-4 text-muted-foreground">
+              Match PayPal costs while staying fully in the Stripe ecosystem.
+            </p>
+            <Card className="mx-auto mt-8 max-w-xl border-primary/40">
+              <CardHeader>
+                <CardTitle className="text-4xl font-semibold">0.59% + $0.19</CardTitle>
+                <CardDescription>per transaction processed through EnsureBack</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm text-muted-foreground">
+                <p>Buyer dispute coverage and escrow included.</p>
+                <p>No monthly fees. Volume discounts start at $1M GMV.</p>
+              </CardContent>
+              <div className="flex items-center justify-center gap-3 pb-6">
+                <Button asChild size="lg">
+                  <Link to="/login">Get Started</Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <a href="mailto:sales@ensureback.com">Talk to sales</a>
+                </Button>
+              </div>
+            </Card>
+          </div>
+        </section>
+
+        <section className="bg-primary py-16 text-primary-foreground">
+          <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-6 px-4 text-center md:flex-row md:text-left">
+            <div className="space-y-3">
+              <h2 className="text-3xl font-semibold">Stripe Connect onboarding for merchants</h2>
+              <p className="text-primary-foreground/80">
+                Let sellers onboard instantly with prebuilt Stripe Connect flows. EnsureBack syncs account capabilities and payout
+                schedules automatically.
+              </p>
+            </div>
+            <Button asChild size="lg" variant="secondary" className="text-base">
+              <a
+                href="https://connect.stripe.com/oauth/authorize"
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-2"
+              >
+                Connect with Stripe
+                <ArrowRight className="h-4 w-4" />
+              </a>
+            </Button>
+          </div>
+        </section>
+      </main>
+
+      <footer className="border-t bg-muted/40 py-8 text-sm text-muted-foreground">
+        <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-4 md:flex-row">
+          <p>© {new Date().getFullYear()} EnsureBack. All rights reserved.</p>
+          <div className="flex items-center gap-6">
+            <Link to="/developer" className="transition-colors hover:text-foreground">
+              Docs
+            </Link>
+            <a href="/terms" className="transition-colors hover:text-foreground">
+              Terms
+            </a>
+            <a href="/privacy" className="transition-colors hover:text-foreground">
+              Privacy
+            </a>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default Landing;

--- a/ensureback-ui/src/pages/Login.tsx
+++ b/ensureback-ui/src/pages/Login.tsx
@@ -1,0 +1,96 @@
+import { FormEvent, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { isAxiosError } from 'axios';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { useAuth } from '@/hooks/useAuth';
+
+const Login = () => {
+  const navigate = useNavigate();
+  const { isAuthenticated, isLoggingIn, loginError, login } = useAuth();
+  const [email, setEmail] = useState('demo@ensureback.test');
+  const [password, setPassword] = useState('demo-password-hash');
+
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    try {
+      await login({ email, password });
+      navigate('/dashboard');
+    } catch (error) {
+      console.error('Login failed', error);
+    }
+  };
+
+  const renderError = () => {
+    if (!loginError) {
+      return null;
+    }
+
+    if (isAxiosError(loginError)) {
+      const message = loginError.response?.data?.message ?? 'Invalid credentials';
+      return <p className="rounded-md bg-red-100 px-3 py-2 text-sm font-medium text-red-700">{message}</p>;
+    }
+
+    return (
+      <p className="rounded-md bg-red-100 px-3 py-2 text-sm font-medium text-red-700">
+        Something went wrong. Please try again.
+      </p>
+    );
+  };
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center bg-muted/60 px-4 py-16">
+      <Card className="w-full max-w-md border-primary/20 shadow-lg">
+        <CardHeader className="space-y-2 text-center">
+          <CardTitle>EnsureBack Portal</CardTitle>
+          <CardDescription>Sign in with your EnsureBack merchant credentials.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div className="space-y-2">
+              <label htmlFor="email" className="text-sm font-medium">
+                Email
+              </label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                required
+                autoComplete="email"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="password" className="text-sm font-medium">
+                Password
+              </label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                required
+                autoComplete="current-password"
+              />
+            </div>
+
+            {renderError()}
+
+            <Button type="submit" className="w-full" disabled={isLoggingIn}>
+              {isLoggingIn ? 'Signing in…' : 'Sign in'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Login;

--- a/ensureback-ui/src/vite-env.d.ts
+++ b/ensureback-ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/ensureback-ui/tailwind.config.js
+++ b/ensureback-ui/tailwind.config.js
@@ -1,0 +1,71 @@
+import animate from 'tailwindcss-animate';
+import { fontFamily } from 'tailwindcss/defaultTheme';
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))'
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))'
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))'
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))'
+        }
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: `calc(var(--radius) - 2px)`,
+        sm: 'calc(var(--radius) - 4px)'
+      },
+      fontFamily: {
+        sans: ['Inter', ...fontFamily.sans]
+      },
+      keyframes: {
+        'accordion-down': {
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' }
+        },
+        'accordion-up': {
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' }
+        }
+      },
+      animation: {
+        'accordion-down': 'accordion-down 0.2s ease-out',
+        'accordion-up': 'accordion-up 0.2s ease-out'
+      }
+    }
+  },
+  plugins: [animate]
+};
+
+export default config;

--- a/ensureback-ui/tsconfig.json
+++ b/ensureback-ui/tsconfig.json
@@ -1,0 +1,35 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    }
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    }
+  ]
+}

--- a/ensureback-ui/tsconfig.node.json
+++ b/ensureback-ui/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true,
+    "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/ensureback-ui/vite.config.ts
+++ b/ensureback-ui/vite.config.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath, URL } from 'node:url';
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  server: {
+    port: 5173,
+    host: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, '/api')
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- integrate shadcn/ui primitives, Tailwind theme tokens, and alias tooling to support a richer design system
- build a marketing landing page plus developer center alongside a reusable navbar with public and authenticated routes
- expand the merchant dashboard and buyer portal with tabbed views, tables, dispute tooling, and mock API fallbacks using React Query

## Testing
- npm install *(fails: npm registry 403 in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97e718f68832a82d79292c028ac8c