### PR TITLE
Implement Stripe Connect OAuth authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# EnsureBack
+
+## Stripe Connect Login Configuration
+
+EnsureBack now authenticates merchants via Stripe Connect rather than email/password credentials. Configure the following environment variables before running the application:
+
+- `STRIPE_CONNECT_CLIENT_ID` – The Connect client identifier from your Stripe dashboard. It is required to build the OAuth authorization URL and to exchange the returned authorization code.
+- `STRIPE_CONNECT_REDIRECT_URI` – The absolute URL Stripe should redirect to after the merchant approves access. This should resolve to the EnsureBack login route in your deployed environment (for local development the backend defaults to `http://localhost:5173/login`).
+- `STRIPE_SECRET_KEY` – The platform secret key that is used to exchange the authorization code for the connected account identifier.
+
+Ensure that the redirect URI configured in Stripe exactly matches the value supplied via `STRIPE_CONNECT_REDIRECT_URI`. The frontend login page expects the callback query parameters (`code`, `state`, `error`, and `error_description`) on that route and finalizes authentication by invoking the backend callback endpoint.

--- a/ensureback-ui/src/api/auth.ts
+++ b/ensureback-ui/src/api/auth.ts
@@ -1,10 +1,5 @@
 import axiosClient, { TOKEN_STORAGE_KEY } from './axiosClient';
 
-export interface LoginRequest {
-  email: string;
-  password: string;
-}
-
 export interface LoginResponse {
   accessToken: string;
   tokenType: string;
@@ -12,8 +7,32 @@ export interface LoginResponse {
   role: string;
 }
 
-export const login = async (payload: LoginRequest): Promise<LoginResponse> => {
-  const response = await axiosClient.post<LoginResponse>('/auth/login', payload);
+export interface StripeConnectStartRequest {
+  email: string;
+}
+
+export interface StripeConnectStartResponse {
+  authorizationUrl: string;
+}
+
+export interface StripeConnectCallbackRequest {
+  state: string;
+  code?: string;
+  error?: string;
+  errorDescription?: string;
+}
+
+export const startStripeConnect = async (
+  payload: StripeConnectStartRequest
+): Promise<StripeConnectStartResponse> => {
+  const response = await axiosClient.post<StripeConnectStartResponse>('/auth/connect/start', payload);
+  return response.data;
+};
+
+export const completeStripeConnect = async (
+  payload: StripeConnectCallbackRequest
+): Promise<LoginResponse> => {
+  const response = await axiosClient.post<LoginResponse>('/auth/connect/callback', payload);
   return response.data;
 };
 

--- a/ensureback-ui/src/hooks/useAuth.ts
+++ b/ensureback-ui/src/hooks/useAuth.ts
@@ -1,7 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { login as loginRequest, logout as logoutRequest, LoginRequest, LoginResponse } from '../api/auth';
+import {
+  completeStripeConnect,
+  LoginResponse,
+  logout as logoutRequest,
+  startStripeConnect,
+  StripeConnectCallbackRequest,
+  StripeConnectStartRequest,
+  StripeConnectStartResponse,
+} from '../api/auth';
 import { TOKEN_STORAGE_KEY } from '../api/axiosClient';
 
 const getInitialToken = (): string | null => {
@@ -14,9 +22,12 @@ const getInitialToken = (): string | null => {
 interface UseAuthResult {
   token: string | null;
   isAuthenticated: boolean;
-  isLoggingIn: boolean;
-  loginError: unknown;
-  login: (credentials: LoginRequest) => Promise<LoginResponse>;
+  isInitiating: boolean;
+  isCompleting: boolean;
+  initiateError: unknown;
+  completeError: unknown;
+  initiateConnect: (payload: StripeConnectStartRequest) => Promise<StripeConnectStartResponse>;
+  completeConnect: (payload: StripeConnectCallbackRequest) => Promise<LoginResponse>;
   logout: () => void;
 }
 
@@ -35,8 +46,12 @@ export const useAuth = (): UseAuthResult => {
     return () => window.removeEventListener('storage', handler);
   }, []);
 
-  const loginMutation = useMutation({
-    mutationFn: (credentials: LoginRequest) => loginRequest(credentials),
+  const initiateMutation = useMutation({
+    mutationFn: (payload: StripeConnectStartRequest) => startStripeConnect(payload),
+  });
+
+  const completeMutation = useMutation({
+    mutationFn: (payload: StripeConnectCallbackRequest) => completeStripeConnect(payload),
     onSuccess: (data) => {
       if (typeof window !== 'undefined') {
         window.localStorage.setItem(TOKEN_STORAGE_KEY, data.accessToken);
@@ -51,20 +66,37 @@ export const useAuth = (): UseAuthResult => {
     queryClient.clear();
   }, [queryClient]);
 
-  const login = useCallback(
-    (credentials: LoginRequest) => loginMutation.mutateAsync(credentials),
-    [loginMutation]
+  const initiateConnect = useCallback(
+    (payload: StripeConnectStartRequest) => initiateMutation.mutateAsync(payload),
+    [initiateMutation]
+  );
+
+  const completeConnect = useCallback(
+    (payload: StripeConnectCallbackRequest) => completeMutation.mutateAsync(payload),
+    [completeMutation]
   );
 
   return useMemo(
     () => ({
       token,
       isAuthenticated: Boolean(token),
-      isLoggingIn: loginMutation.isPending,
-      loginError: loginMutation.error,
-      login,
+      isInitiating: initiateMutation.isPending,
+      isCompleting: completeMutation.isPending,
+      initiateError: initiateMutation.error,
+      completeError: completeMutation.error,
+      initiateConnect,
+      completeConnect,
       logout,
     }),
-    [login, loginMutation.error, loginMutation.isPending, logout, token]
+    [
+      completeConnect,
+      completeMutation.error,
+      completeMutation.isPending,
+      initiateConnect,
+      initiateMutation.error,
+      initiateMutation.isPending,
+      logout,
+      token,
+    ]
   );
 };

--- a/ensureback-ui/src/pages/Login.tsx
+++ b/ensureback-ui/src/pages/Login.tsx
@@ -1,5 +1,5 @@
-import { FormEvent, useState } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { Navigate, useNavigate, useSearchParams } from 'react-router-dom';
 import { isAxiosError } from 'axios';
 
 import { Button } from '@/components/ui/button';
@@ -9,9 +9,28 @@ import { useAuth } from '@/hooks/useAuth';
 
 const Login = () => {
   const navigate = useNavigate();
-  const { isAuthenticated, isLoggingIn, loginError, login } = useAuth();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const {
+    isAuthenticated,
+    isInitiating,
+    isCompleting,
+    initiateError,
+    completeError,
+    initiateConnect,
+    completeConnect,
+  } = useAuth();
   const [email, setEmail] = useState('demo@ensureback.test');
-  const [password, setPassword] = useState('demo-password-hash');
+  const [callbackHandled, setCallbackHandled] = useState(false);
+
+  const callbackParams = useMemo(
+    () => ({
+      code: searchParams.get('code') ?? undefined,
+      state: searchParams.get('state') ?? undefined,
+      error: searchParams.get('error') ?? undefined,
+      errorDescription: searchParams.get('error_description') ?? undefined,
+    }),
+    [searchParams]
+  );
 
   if (isAuthenticated) {
     return <Navigate to="/dashboard" replace />;
@@ -20,20 +39,46 @@ const Login = () => {
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     try {
-      await login({ email, password });
-      navigate('/dashboard');
+      const response = await initiateConnect({ email });
+      window.location.href = response.authorizationUrl;
     } catch (error) {
       console.error('Login failed', error);
     }
   };
 
+  useEffect(() => {
+    if (!callbackParams.state || callbackHandled) {
+      return;
+    }
+
+    setCallbackHandled(true);
+
+    const executeCallback = async () => {
+      try {
+        await completeConnect({
+          state: callbackParams.state!,
+          code: callbackParams.code,
+          error: callbackParams.error,
+          errorDescription: callbackParams.errorDescription,
+        });
+        setSearchParams({}, { replace: true });
+        navigate('/dashboard');
+      } catch (error) {
+        console.error('Stripe Connect callback failed', error);
+      }
+    };
+
+    void executeCallback();
+  }, [callbackHandled, callbackParams, completeConnect, navigate, setSearchParams]);
+
   const renderError = () => {
-    if (!loginError) {
+    const error = completeError ?? initiateError;
+    if (!error) {
       return null;
     }
 
-    if (isAxiosError(loginError)) {
-      const message = loginError.response?.data?.message ?? 'Invalid credentials';
+    if (isAxiosError(error)) {
+      const message = error.response?.data?.message ?? 'Unable to authenticate with Stripe Connect';
       return <p className="rounded-md bg-red-100 px-3 py-2 text-sm font-medium text-red-700">{message}</p>;
     }
 
@@ -64,29 +109,25 @@ const Login = () => {
                 onChange={(event) => setEmail(event.target.value)}
                 required
                 autoComplete="email"
-              />
-            </div>
-
-            <div className="space-y-2">
-              <label htmlFor="password" className="text-sm font-medium">
-                Password
-              </label>
-              <Input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                required
-                autoComplete="current-password"
+                disabled={isInitiating || isCompleting}
               />
             </div>
 
             {renderError()}
 
-            <Button type="submit" className="w-full" disabled={isLoggingIn}>
-              {isLoggingIn ? 'Signing in…' : 'Sign in'}
+            <Button type="submit" className="w-full" disabled={isInitiating || isCompleting}>
+              {isCompleting
+                ? 'Finalizing Stripe login…'
+                : isInitiating
+                ? 'Redirecting to Stripe…'
+                : 'Sign in with Stripe Connect'}
             </Button>
           </form>
+          {isCompleting && (
+            <p className="mt-4 text-center text-sm text-muted-foreground">
+              Returning from Stripe. Please wait while we verify your account…
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/ensureback-ui/tsconfig.node.json
+++ b/ensureback-ui/tsconfig.node.json
@@ -3,8 +3,7 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true,
-    "noEmit": true
+    "allowSyntheticDefaultImports": true
   },
   "include": ["vite.config.ts"]
 }

--- a/src/main/java/com/ensureback/auth/AuthController.java
+++ b/src/main/java/com/ensureback/auth/AuthController.java
@@ -1,38 +1,37 @@
 package com.ensureback.auth;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.ensureback.auth.dto.LoginRequest;
 import com.ensureback.auth.dto.LoginResponse;
-import com.ensureback.security.EnsurebackUserDetails;
-import com.ensureback.security.JwtTokenService;
+import com.ensureback.auth.dto.StripeConnectCallbackRequest;
+import com.ensureback.auth.dto.StripeConnectStartRequest;
+import com.ensureback.auth.dto.StripeConnectStartResponse;
+import com.stripe.exception.StripeException;
 
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private final AuthenticationManager authenticationManager;
-    private final JwtTokenService jwtTokenService;
+    private final StripeConnectService stripeConnectService;
 
-    public AuthController(AuthenticationManager authenticationManager, JwtTokenService jwtTokenService) {
-        this.authenticationManager = authenticationManager;
-        this.jwtTokenService = jwtTokenService;
+    public AuthController(StripeConnectService stripeConnectService) {
+        this.stripeConnectService = stripeConnectService;
     }
 
-    @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@Validated @RequestBody LoginRequest request) {
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(request.email(), request.password()));
-        EnsurebackUserDetails principal = (EnsurebackUserDetails) authentication.getPrincipal();
-        var token = jwtTokenService.createToken(principal.getUser());
-        return ResponseEntity.ok(new LoginResponse(token.value(), "Bearer", token.expiresAt(), principal.getUser().getRole().name()));
+    @PostMapping("/connect/start")
+    public ResponseEntity<StripeConnectStartResponse> start(@Validated @RequestBody StripeConnectStartRequest request) {
+        StripeConnectStartResponse response = stripeConnectService.start(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/connect/callback")
+    public ResponseEntity<LoginResponse> callback(@Validated @RequestBody StripeConnectCallbackRequest request) throws StripeException {
+        LoginResponse response = stripeConnectService.complete(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/ensureback/auth/StripeConnectService.java
+++ b/src/main/java/com/ensureback/auth/StripeConnectService.java
@@ -1,0 +1,161 @@
+package com.ensureback.auth;
+
+import com.ensureback.auth.dto.LoginResponse;
+import com.ensureback.auth.dto.StripeConnectCallbackRequest;
+import com.ensureback.auth.dto.StripeConnectStartRequest;
+import com.ensureback.auth.dto.StripeConnectStartResponse;
+import com.ensureback.security.JwtTokenService;
+import com.ensureback.stripe.StripeProperties;
+import com.ensureback.user.User;
+import com.ensureback.user.UserRepository;
+import com.stripe.Stripe;
+import com.stripe.exception.AuthenticationException;
+import com.stripe.exception.InvalidRequestException;
+import com.stripe.exception.StripeException;
+import com.stripe.model.oauth.TokenResponse;
+import com.stripe.net.OAuth;
+import com.stripe.net.RequestOptions;
+import java.net.URI;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@Transactional
+public class StripeConnectService {
+
+    private static final Logger log = LoggerFactory.getLogger(StripeConnectService.class);
+    private static final Duration SESSION_TTL = Duration.ofMinutes(15);
+
+    private final StripeConnectSessionRepository sessionRepository;
+    private final UserRepository userRepository;
+    private final JwtTokenService jwtTokenService;
+    private final StripeProperties stripeProperties;
+
+    public StripeConnectService(StripeConnectSessionRepository sessionRepository,
+                                UserRepository userRepository,
+                                JwtTokenService jwtTokenService,
+                                StripeProperties stripeProperties) {
+        this.sessionRepository = sessionRepository;
+        this.userRepository = userRepository;
+        this.jwtTokenService = jwtTokenService;
+        this.stripeProperties = stripeProperties;
+    }
+
+    public StripeConnectStartResponse start(StripeConnectStartRequest request) {
+        ensureStripeConfig();
+        Stripe.apiKey = stripeProperties.getSecretKey();
+        Stripe.clientId = stripeProperties.getConnectClientId();
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Unknown merchant"));
+        if (user.getRole() != User.Role.MERCHANT) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Only merchant accounts can connect with Stripe");
+        }
+
+        StripeConnectSession session = new StripeConnectSession(UUID.randomUUID(), user.getId(), OffsetDateTime.now());
+        sessionRepository.save(session);
+
+        UriComponentsBuilder builder = UriComponentsBuilder
+                .fromUri(URI.create("https://connect.stripe.com/oauth/authorize"))
+                .queryParam("response_type", "code")
+                .queryParam("scope", "read_write")
+                .queryParam("client_id", stripeProperties.getConnectClientId())
+                .queryParam("redirect_uri", stripeProperties.getConnectRedirectUri())
+                .queryParam("state", session.getState().toString());
+
+        builder.queryParam("stripe_user[email]", user.getEmail());
+
+        String authorizeUrl = builder.build(true).toUriString();
+        log.debug("Initialized Stripe Connect session {} for user {}", session.getState(), user.getId());
+        return new StripeConnectStartResponse(authorizeUrl);
+    }
+
+    public LoginResponse complete(StripeConnectCallbackRequest request) throws StripeException {
+        ensureStripeConfig();
+        Stripe.apiKey = stripeProperties.getSecretKey();
+        Stripe.clientId = stripeProperties.getConnectClientId();
+        UUID state = parseState(request.state());
+        Optional<StripeConnectSession> sessionOpt = sessionRepository.findById(state);
+        if (sessionOpt.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown or expired Stripe Connect session");
+        }
+        StripeConnectSession session = sessionOpt.get();
+        if (session.getCreatedAt().isBefore(OffsetDateTime.now().minus(SESSION_TTL))) {
+            sessionRepository.delete(session);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Stripe Connect session has expired");
+        }
+        if (request.error() != null) {
+            sessionRepository.delete(session);
+            String message = Optional.ofNullable(request.errorDescription())
+                    .orElse("Stripe authorization failed: " + request.error());
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, message);
+        }
+
+        User user = userRepository.findById(session.getUserId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Merchant no longer exists"));
+
+        String code = Optional.ofNullable(request.code())
+                .map(String::trim)
+                .filter(value -> !value.isEmpty())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "Missing Stripe authorization code"));
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("grant_type", "authorization_code");
+        params.put("code", code);
+
+        RequestOptions requestOptions = RequestOptions.builder()
+                .setApiKey(stripeProperties.getSecretKey())
+                .setClientId(stripeProperties.getConnectClientId())
+                .build();
+
+        TokenResponse tokenResponse;
+        try {
+            tokenResponse = OAuth.token(params, requestOptions);
+        } catch (AuthenticationException | InvalidRequestException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unable to authorize Stripe account", ex);
+        }
+
+        String stripeAccountId = tokenResponse.getStripeUserId();
+        if (stripeAccountId == null || stripeAccountId.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Stripe did not return an account identifier");
+        }
+
+        user.setStripeAccountId(stripeAccountId);
+        userRepository.save(user);
+        sessionRepository.delete(session);
+
+        var token = jwtTokenService.createToken(user);
+        log.info("Stripe Connect login complete for user {} with account {}", user.getId(), stripeAccountId);
+        return new LoginResponse(token.value(), "Bearer", token.expiresAt(), user.getRole().name());
+    }
+
+    private void ensureStripeConfig() {
+        if (stripeProperties.getSecretKey() == null || stripeProperties.getSecretKey().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Stripe secret key is not configured");
+        }
+        if (stripeProperties.getConnectClientId() == null || stripeProperties.getConnectClientId().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Stripe Connect client id is not configured");
+        }
+        if (stripeProperties.getConnectRedirectUri() == null || stripeProperties.getConnectRedirectUri().isBlank()) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Stripe Connect redirect URI is not configured");
+        }
+    }
+
+    private UUID parseState(String stateValue) {
+        try {
+            return UUID.fromString(stateValue);
+        } catch (IllegalArgumentException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid Stripe Connect state parameter", ex);
+        }
+    }
+}

--- a/src/main/java/com/ensureback/auth/StripeConnectSession.java
+++ b/src/main/java/com/ensureback/auth/StripeConnectSession.java
@@ -1,0 +1,57 @@
+package com.ensureback.auth;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "stripe_connect_sessions")
+public class StripeConnectSession {
+
+    @Id
+    @Column(name = "state", nullable = false)
+    private UUID state;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    protected StripeConnectSession() {
+        // JPA
+    }
+
+    public StripeConnectSession(UUID state, UUID userId, OffsetDateTime createdAt) {
+        this.state = state;
+        this.userId = userId;
+        this.createdAt = createdAt;
+    }
+
+    public UUID getState() {
+        return state;
+    }
+
+    public void setState(UUID state) {
+        this.state = state;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/ensureback/auth/StripeConnectSessionRepository.java
+++ b/src/main/java/com/ensureback/auth/StripeConnectSessionRepository.java
@@ -1,0 +1,7 @@
+package com.ensureback.auth;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StripeConnectSessionRepository extends JpaRepository<StripeConnectSession, UUID> {
+}

--- a/src/main/java/com/ensureback/auth/dto/StripeConnectCallbackRequest.java
+++ b/src/main/java/com/ensureback/auth/dto/StripeConnectCallbackRequest.java
@@ -1,0 +1,9 @@
+package com.ensureback.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record StripeConnectCallbackRequest(@NotBlank String state,
+                                           String code,
+                                           String error,
+                                           String errorDescription) {
+}

--- a/src/main/java/com/ensureback/auth/dto/StripeConnectStartRequest.java
+++ b/src/main/java/com/ensureback/auth/dto/StripeConnectStartRequest.java
@@ -3,8 +3,5 @@ package com.ensureback.auth.dto;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
-public record LoginRequest(
-        @Email @NotBlank String email,
-        @NotBlank String password
-) {
+public record StripeConnectStartRequest(@Email @NotBlank String email) {
 }

--- a/src/main/java/com/ensureback/auth/dto/StripeConnectStartResponse.java
+++ b/src/main/java/com/ensureback/auth/dto/StripeConnectStartResponse.java
@@ -1,0 +1,4 @@
+package com.ensureback.auth.dto;
+
+public record StripeConnectStartResponse(String authorizationUrl) {
+}

--- a/src/main/java/com/ensureback/security/SecurityConfig.java
+++ b/src/main/java/com/ensureback/security/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/health", "/api/auth/login", "/api/buyer/magic-link/**", "/ws/**", "/dev/docs").permitAll()
+                        .requestMatchers("/health", "/api/auth/connect/**", "/api/buyer/magic-link/**", "/ws/**", "/dev/docs").permitAll()
                         .requestMatchers(HttpMethod.POST, "/dev/register-keys").authenticated()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/ensureback/stripe/StripeProperties.java
+++ b/src/main/java/com/ensureback/stripe/StripeProperties.java
@@ -7,10 +7,17 @@ public class StripeProperties {
 
     private final String secretKey;
     private final String webhookSecret;
+    private final String connectClientId;
+    private final String connectRedirectUri;
 
-    public StripeProperties(String secretKey, String webhookSecret) {
+    public StripeProperties(String secretKey,
+                            String webhookSecret,
+                            String connectClientId,
+                            String connectRedirectUri) {
         this.secretKey = secretKey;
         this.webhookSecret = webhookSecret;
+        this.connectClientId = connectClientId;
+        this.connectRedirectUri = connectRedirectUri;
     }
 
     public String getSecretKey() {
@@ -19,5 +26,13 @@ public class StripeProperties {
 
     public String getWebhookSecret() {
         return webhookSecret;
+    }
+
+    public String getConnectClientId() {
+        return connectClientId;
+    }
+
+    public String getConnectRedirectUri() {
+        return connectRedirectUri;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,8 @@ magic-link:
 stripe:
   secret-key: ${STRIPE_SECRET_KEY:}
   webhook-secret: ${STRIPE_WEBHOOK_SECRET:}
+  connect-client-id: ${STRIPE_CONNECT_CLIENT_ID:}
+  connect-redirect-uri: ${STRIPE_CONNECT_REDIRECT_URI:http://localhost:5173/login}
 
 aftership:
   api-key: ${AFTERSHIP_API_KEY:}

--- a/src/main/resources/db/migration/V11__stripe_connect_sessions.sql
+++ b/src/main/resources/db/migration/V11__stripe_connect_sessions.sql
@@ -1,0 +1,5 @@
+CREATE TABLE stripe_connect_sessions (
+    state UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- replace the password-based login controller with Stripe Connect OAuth start and callback endpoints that issue the EnsureBack JWT
- persist Connect session state and the returned Stripe account identifier, expanding Stripe configuration and adding a migration for session storage
- update the React auth client, hook, and login page to launch the Connect flow, process the callback, and document the new environment variables

## Testing
- mvn -DskipTests package
- npm --prefix ensureback-ui run build *(fails: existing `DialogPortalProps` typing does not expose `className`)*

------
https://chatgpt.com/codex/tasks/task_e_68dae073fa74832a840a8780afde4369