### PR TITLE
Surface backend detail in Connect errors

### DIFF
--- a/ensureback-ui/src/pages/Login.tsx
+++ b/ensureback-ui/src/pages/Login.tsx
@@ -78,7 +78,9 @@ const Login = () => {
     }
 
     if (isAxiosError(error)) {
-      const message = error.response?.data?.message ?? 'Unable to authenticate with Stripe Connect';
+      const data = error.response?.data;
+      const message =
+        data?.detail ?? data?.title ?? data?.message ?? 'Unable to authenticate with Stripe Connect';
       return <p className="rounded-md bg-red-100 px-3 py-2 text-sm font-medium text-red-700">{message}</p>;
     }
 


### PR DESCRIPTION
## Summary
- allow the login error renderer to display backend-provided detail or title fields before falling back to the legacy message

## Testing
- npm run lint *(fails: existing project configuration lacks JSX runtime types)*

------
https://chatgpt.com/codex/tasks/task_e_68dae87b110c832a97b6f7c9adc287ea