### PR TITLE
Fix merchant status authentication handling

### DIFF
--- a/ensureback-ui/src/api/axiosClient.ts
+++ b/ensureback-ui/src/api/axiosClient.ts
@@ -1,7 +1,24 @@
-﻿import axios from "axios";
+import axios from "axios";
 
 export const API_BASE_URL = '/api';
 export const TOKEN_STORAGE_KEY = 'ensureback_token';
+
+export const buildAuthorizationHeader = (token: string | null | undefined): string | null => {
+  if (!token) {
+    return null;
+  }
+
+  const normalized = token.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized.toLowerCase().startsWith('bearer ')) {
+    return normalized;
+  }
+
+  return `Bearer ${normalized}`;
+};
 
 export const readStoredToken = (): string | null => {
   if (typeof window === 'undefined') {
@@ -50,9 +67,10 @@ const axiosClient = axios.create({
 
 axiosClient.interceptors.request.use((config) => {
   const token = readStoredToken();
-  if (token) {
+  const authorization = buildAuthorizationHeader(token);
+  if (authorization) {
     config.headers = config.headers ?? {};
-    config.headers.Authorization = `Bearer ${token}`;
+    config.headers.Authorization = authorization;
   }
   return config;
 });

--- a/ensureback-ui/src/hooks/useAuth.ts
+++ b/ensureback-ui/src/hooks/useAuth.ts
@@ -3,7 +3,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
 import { clearSession } from '../api/auth';
-import axiosClient, { TOKEN_STORAGE_KEY, clearStoredToken, persistToken, readStoredToken } from '../api/axiosClient';
+import axiosClient, {
+  TOKEN_STORAGE_KEY,
+  buildAuthorizationHeader,
+  clearStoredToken,
+  persistToken,
+  readStoredToken,
+} from '../api/axiosClient';
 
 interface SessionState {
   token: string;
@@ -228,7 +234,10 @@ export const useAuth = (): UseAuthResult => {
       setMerchantStatusError(null);
 
       try {
-        const response = await axiosClient.get<MerchantStatusResponse>('/merchant/status');
+        const authorization = buildAuthorizationHeader(currentSession.token);
+        const response = await axiosClient.get<MerchantStatusResponse>('/merchant/status', {
+          headers: authorization ? { Authorization: authorization } : undefined,
+        });
         manualMerchantStatusRef.current = false;
         setMerchantStatus(response.data);
         setMerchantStatusError(null);

--- a/ensureback-ui/src/pages/StripeConnectCallback.tsx
+++ b/ensureback-ui/src/pages/StripeConnectCallback.tsx
@@ -37,14 +37,28 @@ const StripeConnectCallback = () => {
           },
         });
 
-        const rawMessage = response.data?.message;
+        const responseData = (response.data ?? {}) as Record<string, unknown>;
+        const directToken = typeof responseData.accessToken === 'string' ? responseData.accessToken : null;
+        const legacyToken = typeof responseData.token === 'string' ? responseData.token : null;
+        const nestedLogin =
+          responseData.login && typeof responseData.login === 'object'
+            ? (responseData.login as Record<string, unknown>)
+            : null;
+        const nestedToken = nestedLogin && typeof nestedLogin.accessToken === 'string' ? nestedLogin.accessToken : null;
+        const sessionToken = directToken ?? legacyToken ?? nestedToken;
+
+        if (sessionToken) {
+          setSessionFromToken(sessionToken);
+        }
+
+        const rawMessage = responseData.message;
         if (typeof rawMessage === 'string' && rawMessage.trim().length > 0) {
           setStatusMessage(rawMessage);
         } else {
           setStatusMessage('Verifying your account details...');
         }
 
-        const redirectHint: unknown = response.data?.redirectUrl;
+        const redirectHint: unknown = responseData.redirectUrl;
         let cleanedRedirect: string | null = null;
 
         if (typeof redirectHint === 'string' && redirectHint.trim().length > 0) {


### PR DESCRIPTION
## Summary
- normalize stored tokens into Authorization headers for API requests
- send the merchant status request with the active bearer token and persist callback tokens
- capture Stripe callback login tokens directly from the response before refreshing status

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2da55cc0c832a8f5deda918948688