### PR TITLE
Handle missing merchant record after Stripe connect

### DIFF
--- a/ensureback-ui/src/api/axiosClient.ts
+++ b/ensureback-ui/src/api/axiosClient.ts
@@ -1,7 +1,24 @@
-﻿import axios from "axios";
+import axios from "axios";
 
 export const API_BASE_URL = '/api';
 export const TOKEN_STORAGE_KEY = 'ensureback_token';
+
+export const buildAuthorizationHeader = (token: string | null | undefined): string | null => {
+  if (!token) {
+    return null;
+  }
+
+  const normalized = token.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  if (normalized.toLowerCase().startsWith('bearer ')) {
+    return normalized;
+  }
+
+  return `Bearer ${normalized}`;
+};
 
 export const readStoredToken = (): string | null => {
   if (typeof window === 'undefined') {
@@ -50,9 +67,10 @@ const axiosClient = axios.create({
 
 axiosClient.interceptors.request.use((config) => {
   const token = readStoredToken();
-  if (token) {
+  const authorization = buildAuthorizationHeader(token);
+  if (authorization) {
     config.headers = config.headers ?? {};
-    config.headers.Authorization = `Bearer ${token}`;
+    config.headers.Authorization = authorization;
   }
   return config;
 });

--- a/ensureback-ui/src/hooks/useAuth.ts
+++ b/ensureback-ui/src/hooks/useAuth.ts
@@ -3,7 +3,13 @@ import { useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 
 import { clearSession } from '../api/auth';
-import axiosClient, { TOKEN_STORAGE_KEY, clearStoredToken, persistToken, readStoredToken } from '../api/axiosClient';
+import axiosClient, {
+  TOKEN_STORAGE_KEY,
+  buildAuthorizationHeader,
+  clearStoredToken,
+  persistToken,
+  readStoredToken,
+} from '../api/axiosClient';
 
 interface SessionState {
   token: string;
@@ -228,12 +234,26 @@ export const useAuth = (): UseAuthResult => {
       setMerchantStatusError(null);
 
       try {
-        const response = await axiosClient.get<MerchantStatusResponse>('/merchant/status');
+        const authorization = buildAuthorizationHeader(currentSession.token);
+        const response = await axiosClient.get<MerchantStatusResponse>('/merchant/status', {
+          headers: authorization ? { Authorization: authorization } : undefined,
+        });
         manualMerchantStatusRef.current = false;
         setMerchantStatus(response.data);
         setMerchantStatusError(null);
         return response.data;
       } catch (error) {
+        if (isAxiosError(error) && error.response?.status === 404) {
+          const fallbackStatus: MerchantStatusResponse = {
+            isIntegrated: false,
+            stripeAccountId: currentSession.stripeAccountId || null,
+          };
+          manualMerchantStatusRef.current = false;
+          setMerchantStatus(fallbackStatus);
+          setMerchantStatusError(null);
+          return fallbackStatus;
+        }
+
         console.error('Unable to load merchant status', error);
         manualMerchantStatusRef.current = true;
 
@@ -242,7 +262,10 @@ export const useAuth = (): UseAuthResult => {
           if (status === 401 || status === 403) {
             setMerchantStatusError({ message: 'Session expired, please reconnect Stripe.', status, type: 'auth' });
           } else if (!error.response) {
-            setMerchantStatusError({ message: 'We are having trouble reaching EnsureBack. Check your connection and try again.', type: 'network' });
+            setMerchantStatusError({
+              message: 'We are having trouble reaching EnsureBack. Check your connection and try again.',
+              type: 'network',
+            });
           } else {
             setMerchantStatusError({ message: 'Unable to load merchant status. Please try again later.', status, type: 'unknown' });
           }

--- a/ensureback-ui/src/pages/StripeConnectCallback.tsx
+++ b/ensureback-ui/src/pages/StripeConnectCallback.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useState } from 'react';
+﻿import { useEffect, useMemo, useRef, useState } from 'react';
 import { isAxiosError } from 'axios';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -13,6 +13,7 @@ const StripeConnectCallback = () => {
   const { refreshMerchantStatus, setSessionFromToken } = useAuth();
   const [statusMessage, setStatusMessage] = useState('Finalizing your Stripe connection...');
   const [showRetry, setShowRetry] = useState(false);
+  const hasFinalizedRef = useRef(false);
 
   const searchParams = useMemo(() => {
     const params = new URLSearchParams(location.search ?? window.location.search ?? '');
@@ -26,6 +27,12 @@ const StripeConnectCallback = () => {
       return;
     }
 
+    if (hasFinalizedRef.current) {
+      return;
+    }
+
+    hasFinalizedRef.current = true;
+
     const finalize = async () => {
       setShowRetry(false);
       try {
@@ -37,14 +44,28 @@ const StripeConnectCallback = () => {
           },
         });
 
-        const rawMessage = response.data?.message;
+        const responseData = (response.data ?? {}) as Record<string, unknown>;
+        const directToken = typeof responseData.accessToken === 'string' ? responseData.accessToken : null;
+        const legacyToken = typeof responseData.token === 'string' ? responseData.token : null;
+        const nestedLogin =
+          responseData.login && typeof responseData.login === 'object'
+            ? (responseData.login as Record<string, unknown>)
+            : null;
+        const nestedToken = nestedLogin && typeof nestedLogin.accessToken === 'string' ? nestedLogin.accessToken : null;
+        const sessionToken = directToken ?? legacyToken ?? nestedToken;
+
+        if (sessionToken) {
+          setSessionFromToken(sessionToken);
+        }
+
+        const rawMessage = responseData.message;
         if (typeof rawMessage === 'string' && rawMessage.trim().length > 0) {
           setStatusMessage(rawMessage);
         } else {
           setStatusMessage('Verifying your account details...');
         }
 
-        const redirectHint: unknown = response.data?.redirectUrl;
+        const redirectHint: unknown = responseData.redirectUrl;
         let cleanedRedirect: string | null = null;
 
         if (typeof redirectHint === 'string' && redirectHint.trim().length > 0) {
@@ -118,6 +139,7 @@ const StripeConnectCallback = () => {
           setStatusMessage('Unable to finalize Stripe Connect login. Please try again.');
         }
         setShowRetry(true);
+        hasFinalizedRef.current = false;
       }
     };
 

--- a/ensureback-ui/src/pages/dashboard/merchant/Overview.tsx
+++ b/ensureback-ui/src/pages/dashboard/merchant/Overview.tsx
@@ -1,5 +1,6 @@
 ﻿import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 import { useNavigate } from 'react-router-dom';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { ArrowUpRight, Clock, ShieldCheck, Zap } from 'lucide-react';
@@ -63,7 +64,23 @@ const getRecentCases = (disputes: MerchantDispute[]) =>
 
 const MerchantOverview = () => {
   const profileQuery = useQuery({ queryKey: ['merchant', 'profile'], queryFn: fetchMerchantProfile });
-  const statusQuery = useQuery({ queryKey: ['merchant', 'status'], queryFn: fetchMerchantStatus });
+  const statusQuery = useQuery({
+    queryKey: ['merchant', 'status'],
+    queryFn: fetchMerchantStatus,
+    retry: (failureCount, error) => {
+      if (isAxiosError(error)) {
+        const status = error.response?.status;
+        if (status === 401 || status === 403) {
+          return false;
+        }
+        if (!error.response) {
+          return false;
+        }
+      }
+      return failureCount < 3;
+    },
+    refetchOnWindowFocus: false,
+  });
   const navigate = useNavigate();
 
   const ordersQuery = useQuery({ queryKey: ['merchant', 'orders'], queryFn: fetchOrders });

--- a/ensureback-ui/src/pages/dashboard/merchant/data.ts
+++ b/ensureback-ui/src/pages/dashboard/merchant/data.ts
@@ -1,4 +1,6 @@
-﻿import axiosClient from '@/api/axiosClient';
+﻿import { isAxiosError } from 'axios';
+
+import axiosClient from '@/api/axiosClient';
 
 export interface MerchantProfile {
   id: string;
@@ -56,8 +58,15 @@ export const fetchMerchantProfile = async (): Promise<MerchantProfile> => {
 };
 
 export const fetchMerchantStatus = async (): Promise<MerchantStatus> => {
-  const response = await axiosClient.get<MerchantStatus>('/merchant/status');
-  return response.data;
+  try {
+    const response = await axiosClient.get<MerchantStatus>('/merchant/status');
+    return response.data;
+  } catch (error) {
+    if (isAxiosError(error) && error.response?.status === 404) {
+      return { isIntegrated: false, stripeAccountId: null };
+    }
+    throw error;
+  }
 };
 
 export const fetchOrders = async (): Promise<MerchantOrder[]> => {


### PR DESCRIPTION
## Summary
- normalize stored tokens into Authorization headers for API requests
- send the merchant status request with the active bearer token and persist callback tokens
- capture Stripe callback login tokens directly from the response before refreshing status
- treat a 404 merchant status response as a pending integration and avoid duplicate Stripe callback submissions
- stop merchant dashboard polling retries on authorization or network failures

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2da55cc0c832a8f5deda918948688